### PR TITLE
Add simple blockchain commitment API

### DIFF
--- a/fiber/chain_interactions/chain_utils.py
+++ b/fiber/chain_interactions/chain_utils.py
@@ -50,6 +50,19 @@ def create_scale_object_from_scale_encoding(
     return scale_object.decode()
 
 
+def format_error_message(error_message: dict | None) -> str:
+    err_type, err_name, err_description = (
+        "UnknownType",
+        "UnknownError",
+        "Unknown Description",
+    )
+    if isinstance(error_message, dict):
+        err_type = error_message.get("type", err_type)
+        err_name = error_message.get("name", err_name)
+        err_description = error_message.get("docs", [err_description])[0]
+    return f"substrate returned `{err_name} ({err_type})` error. Description: `{err_description}`"
+
+
 def get_hotkey_file_path(wallet_name: str, hotkey_name: str) -> Path:
     file_path = Path.home() / ".bittensor" / "wallets" / wallet_name / "hotkeys" / hotkey_name
     return file_path

--- a/fiber/chain_interactions/commitments.py
+++ b/fiber/chain_interactions/commitments.py
@@ -1,0 +1,213 @@
+from enum import Enum
+from typing import TypeAlias
+
+from pydantic import BaseModel
+from scalecodec import ScaleType
+from substrateinterface import SubstrateInterface, Keypair
+from tenacity import retry, stop_after_attempt, wait_exponential
+
+from fiber.chain_interactions.weights import log_and_reraise, send_extrinsic
+
+
+class DataFieldType(Enum):
+    RAW = "Raw"
+    BLAKE_TWO_256 = "BlakeTwo256"
+    SHA_256 = "Sha256"
+    KECCAK_256 = "Keccak256"
+    SHA_THREE_256 = "ShaThree256"
+
+
+CommitmentDataField: TypeAlias = tuple[DataFieldType, bytes] | None
+
+
+class CommitmentQuery(BaseModel):
+    fields: list[CommitmentDataField]
+    block: int
+    deposit: int
+
+
+class RawCommitment(BaseModel):
+    data: bytes
+    block: int
+    deposit: int
+
+
+def _serialize_field(field: CommitmentDataField):
+    if not field:
+        return {str(None): b''}
+
+    data_type, data = field
+
+    if data_type == DataFieldType.RAW:
+        serialized_data_type = DataFieldType.RAW.value + str(len(data))
+    else:
+        serialized_data_type = data_type.value
+
+    return {serialized_data_type: data}
+
+
+def _deserialize_field(field: dict[str, bytes]) -> CommitmentDataField:
+    data_type, data = field.items().__iter__().__next__()
+
+    if data_type == str(None):
+        return None
+
+    if data_type == DataFieldType.RAW.value + str(len(data)):
+        return DataFieldType.RAW, data
+    elif data_type.startswith(DataFieldType.RAW.value):
+        raise ValueError(f"Got commitment field type {data_type} but data size {len(data)}")
+
+    return DataFieldType[data_type], data
+
+
+@retry(
+    stop=stop_after_attempt(3),
+    wait=wait_exponential(multiplier=1, min=1, max=4),
+    reraise=True,
+)
+def _query_commitment(
+    substrate: SubstrateInterface,
+    netuid: int,
+    hotkey: str,
+    block: int | None = None,
+) -> ScaleType:
+    return substrate.query(
+        module="Commitments",
+        storage_function="CommitmentOf",
+        params=[netuid, hotkey],
+        block_hash=(None if block is None else substrate.get_block_hash(block)),  # type: ignore
+    )
+
+
+@retry(
+    stop=stop_after_attempt(3),
+    wait=wait_exponential(multiplier=1.5, min=2, max=5),
+    reraise=True,
+)
+@log_and_reraise
+def set_commitment(
+    substrate_interface: SubstrateInterface,
+    keypair: Keypair,
+    netuid: int,
+    fields: list[CommitmentDataField],
+    wait_for_inclusion: bool = False,
+    wait_for_finalization: bool = False,
+) -> tuple[bool, str | None]:
+    """
+    Commit custom fields to the chain
+    Arguments:
+        fields: A list of fields as data type to value tuples, for example (DataFieldType.RAW, b'hello world')
+    """
+
+    mapped_fields = [[
+        _serialize_field(field)
+        for field in fields
+    ]]
+
+    call = substrate_interface.compose_call(
+        call_module="Commitments",
+        call_function="set_commitment",
+        call_params={
+            "netuid": netuid,
+            "info": {
+                "fields": mapped_fields,
+            },
+        },
+    )
+
+    extrinsic = substrate_interface.create_signed_extrinsic(call=call, keypair=keypair)
+
+    return send_extrinsic(
+        substrate_interface,
+        extrinsic,
+        wait_for_inclusion=wait_for_inclusion,
+        wait_for_finalization=wait_for_finalization,
+    )
+
+
+def query_commitment(
+    substrate: SubstrateInterface,
+    netuid: int,
+    hotkey: str,
+    block: int | None = None,
+) -> CommitmentQuery | None:
+    """
+    Query fields commited to the chain via set_commitment
+    return: None if no commitment has been made previously, otherwise CommitmentQuery
+    """
+
+    value = _query_commitment(
+        substrate,
+        netuid,
+        hotkey,
+        block,
+    ).value
+
+    if not value:
+        return None
+
+    fields: list[dict[str, bytes]] = value["info"]["fields"]
+    mapped_fields = [_deserialize_field(field) for field in fields]
+
+    return CommitmentQuery(
+        fields=mapped_fields,
+        block=value["block"],
+        deposit=value["deposit"],
+    )
+
+
+def publish_raw_commitment(
+    substrate_interface: SubstrateInterface,
+    keypair: Keypair,
+    netuid: int,
+    data: bytes,
+    wait_for_inclusion: bool = False,
+    wait_for_finalization: bool = True,
+):
+    """
+    Helper function for publishing a single raw byte-string to the chain using only one commitment field
+    """
+
+    return set_commitment(
+        substrate_interface,
+        keypair,
+        netuid,
+        [(DataFieldType.RAW, data)],
+        wait_for_inclusion,
+        wait_for_finalization
+    )
+
+
+def get_raw_commitment(
+    substrate: SubstrateInterface,
+    netuid: int,
+    hotkey: str,
+    block: int | None = None,
+) -> RawCommitment | None:
+    """
+    Helper function for getting single field raw byte-string value after publishing with publish_raw_commitment
+    returns: None if publish_raw_commitment has not been called before
+    raises: ValueError if set_commitment has been called before with a different data-type
+    """
+
+    commitment = query_commitment(substrate, netuid, hotkey, block)
+    if commitment and len(commitment.fields):
+        field = commitment.fields[0]
+    else:
+        field = None
+
+    if not field:
+        return None
+
+    data_type, data = field
+
+    if data_type != DataFieldType.RAW:
+        raise ValueError(
+            f"Commitment for {hotkey} in netuid {netuid} is of type {data_type.value} and not {DataFieldType.RAW.value}"
+        )
+
+    return RawCommitment(
+        data=data,
+        block=commitment.block,
+        deposit=commitment.deposit,
+    )

--- a/fiber/chain_interactions/weights.py
+++ b/fiber/chain_interactions/weights.py
@@ -116,7 +116,7 @@ def log_and_reraise(func: Callable[..., Any]) -> Callable[..., Any]:
     reraise=True,
 )
 @log_and_reraise
-def _send_extrinsic(
+def send_extrinsic(
     substrate_interface: SubstrateInterface,
     extrinsic_to_send: GenericExtrinsic,
     wait_for_inclusion: bool = False,
@@ -187,7 +187,7 @@ def set_node_weights(
 
     logger.info("Attempting to set weights...")
 
-    success, error_message = _send_extrinsic(
+    success, error_message = send_extrinsic(
         substrate_interface=substrate_interface,
         extrinsic_to_send=extrinsic_to_send,
         wait_for_inclusion=wait_for_inclusion,


### PR DESCRIPTION
New base types:
- DataFieldType: defines what type a commitment field is using(whether Raw data or a type of hash)
- CommitmentDataField: A field to be committed or queried from the chain
- CommitmentQuery: The full result of the commitment query, which includes all committed fields, the block they were committed at, and the deposit made by the hotkey to commit them

New base functions:
- set_commitment: Commit a number of fields to the chain for a set netuid and wallet(fields are `list[CommitmentDataField]`)
- query_commitment: Queries commitment made with `set_commitment`, returns `CommitmentQuery`

Helper types:
- RawCommitment: Includes only the data of one field with raw data and not a hash

Helper functions:
- publish_raw_commitment: Commit a single byte-string to the chain as raw data
- get_raw_commitment: Query existing single byte-string commitment 
